### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,8 @@ jobs:
   create_release:
     name: 'Create release'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Potential fix for [https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/3](https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/3)

To fix the problem, explicitly set the `permissions` block for the job to limit the GITHUB_TOKEN's access. The minimal required permissions for creating a release are `contents: write`, as the `actions/create-release` action needs to create a release in the repository. Other steps (like checking out the code or reading the version from `package.json`) only require read access. Therefore, add a `permissions` block with `contents: write` at the job level (under `create_release:`), which will apply only to this job and not affect other jobs or workflows. No other changes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
