### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy_npm.yml
+++ b/.github/workflows/deploy_npm.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Potential fix for [https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/1](https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow or to the specific job. Since the workflow is only publishing to npm and does not interact with issues, pull requests, or other repository features, the minimal required permission is `contents: read`. This will restrict the GITHUB_TOKEN to only have read access to repository contents, adhering to the principle of least privilege. The change should be made at the job level (under `build:`) or at the root of the workflow, but for clarity and minimal impact, adding it to the job is preferred. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
