### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish-github-packages.yml
+++ b/.github/workflows/npm-publish-github-packages.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Potential fix for [https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/2](https://github.com/WeetLeaf/ytdl-cli/security/code-scanning/2)

To fix the problem, add a `permissions` block to the `build` job in the workflow file. This block should specify the minimum required permissions, which for a build/test job is typically `contents: read`. This change should be made directly under the `build:` job definition (i.e., at the same indentation level as `runs-on`). No other changes are needed, as the `publish-gpr` job already has an appropriate `permissions` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
